### PR TITLE
Fetch errors, such as SSL connect errors, are noted as failures

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -26,7 +26,8 @@ exports.run = function(client, urls, reporter, checker) {
                 return Q('Done');
             }
         }, function(error) {
-           console.log(error);
+           console.log(url + ': ' + error);
+           failures.push(url);
         })
     };
 

--- a/test/runner.spec.js
+++ b/test/runner.spec.js
@@ -45,5 +45,33 @@ describe('runner', function() {
             assert(!checker.check.calledWith(redirectFrom));
             assert(checker.check.calledWith(redirectTo));
         }).then(done).done();
-    }))
+    }));
+
+    it('returns a failed request as a failure', function(done) {
+        // Arrange
+        var client = {
+            request: sinon.stub()
+        };
+        var failingUrl = 'https://test.example.com/failsRequest';
+
+        var urls = [failingUrl];
+        var reporter = {
+            report: sinon.spy(),
+            summarise: sinon.spy()
+        };
+        var checker = { check: sinon.spy() };
+        var runner = require('../runner.js');
+
+        client.request.withArgs(failingUrl).returns(
+            Q.fcall(function() {
+                throw 'Request failure error message';
+            })
+        );
+
+        // Act
+        runner.run(client, urls, reporter, checker).then(function() {
+            // Assert
+            assert(reporter.summarise.calledWith([], [failingUrl]));
+        }).then(done).done();
+    });
 })


### PR DESCRIPTION
Hi @hgcummings 

Currently our script is passing even though there are SSL connection errors to the URLs we're testing. I've tried to make the smallest possible change to resolve this.

Thanks,
Linc